### PR TITLE
dont end call when url is missing

### DIFF
--- a/fleet_notifications/notifications_client.py
+++ b/fleet_notifications/notifications_client.py
@@ -30,7 +30,6 @@ class NotificationClient:
                 return
             if not self._check_url_exists():
                 logger.error("The provided audio file URL does not exist.")
-                return
 
             logger.info("Calling phone number: " + phone_number)
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fleet_notifications"
-version = "2.1.1"
+version = "2.1.2"
 
 [tool.setuptools.packages.find]
 include = ["fleet_notifications", "config"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed an issue where phone calls were not attempted if the audio file URL was missing; calls will now proceed even if the URL check fails.
- **Chores**
	- Updated the project version to 2.1.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->